### PR TITLE
Update abseil and add #include <cstdint> to two files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,24 @@
 # Lc0
 
 Lc0 is a UCI-compliant chess engine designed to play chess via neural network, specifically those of the [LeelaChessZero project](https://lczero.org).
-This is an experimental repository for testing new features to the Lc0 chess engine. Updates are made frequently so there may be bugs. Please report any issues you find to the Lc0 Discord. All elo measurements were calculated on A100.
+This is an experimental repository for testing new features to the Lc0 chess engine. Updates are made frequently so there may be bugs. Please report any issues you find to the Lc0 Discord. All elo measurements were calculated on A100 with unbalanced human openings.
 Many of these features are taken from the Katago engine. A detailed description of these methods can be found [here](https://github.com/lightvector/KataGo/blob/master/docs/KataGoMethods.md). A list of the improvements follows.
 
 
 ## New features in this fork
+
+### Node reporting
+
+The nps statistic used to represent the number of playouts per second, which may not be what the user wants. The new `--reported-nodes` option specifies what the node count and nps statistic represent. 
+The default is `"nodes"` for LowNodes. The other options are `"queries"` for neural network queries and `"playouts"` or `"legacy"` for playouts.
+
 
 ### 50 move rule caching
 
 The first 64 plies out of 100 are partitioned into 8 equally sized buckets. Before a position is queried for NN evaluation, the 50 move rule ply is checked. If the bucket containing the position already has nodes, the eval is copied from the one with the most visits.
 The speedup can be anywhere from 5% to 50% depending on how transposition-heavy the position is. The gain was measured at 20 elo on STC. The nodes per second statistic is now calculated by the number of true nodes (called LowNode in the code) rather than edges (technically playouts, called Node in the code) so the reported value may be lower than on previous dag versions.
 
-This feature is disabled by default but can be enabled by specifying `-m` or `--move-rule-bucketing=true` in the config.
+This feature is enabled by default and can be disabled by specifying `--move-rule-bucketing=false` in the config.
 
 
 ### CPUCT Utility Variance Scaling
@@ -23,20 +29,20 @@ This feature is disabled by default but can be enabled by specifying `-m` or `--
 Identical to the [Katago implementation](https://github.com/lightvector/KataGo/blob/master/docs/KataGoMethods.md#dynamic-variance-scaled-cpuct). The new parameters are
 
 ```
-CPuctUtilityStdevPrior 
-CPuctUtilityStdevScale 
-CPuctUtilityStdevPriorWeight
+--cpuct-utility-stdev-prior 
+--cpuct-utility-stdev-scale
+--cpuct-utility-stdev-prior-weight
 ```
 
-and the tuned values are
+and the tuned values (excluding the prior weight) for masterkni's T1 are
 
 ```
-CPuct 2.3097
-FpuValue 0.5619
-CPuctUtilityStdevPrior 0.2289
-CPuctUtilityStdevScale 0.3437
-CPuctUtilityStdevPriorWeight 10.0 (default, not tuned)
-WDLCalibrationElo 3400
+--cpuct=2.3097
+--fpu-value=0.5619
+--cpuct-utility-stdev-prior=0.2289
+--cpuct-utility-stdev-scale=0.3437
+--cpuct-utility-stdev-prior-weight=10.0
+--wdl-calibration-elo=3400
 ```
 
 The gain  is around 10 elo on STC and LTC.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ Many of these features are taken from the Katago engine. A detailed description 
 ### 50 move rule caching
 
 The first 64 plies out of 100 are partitioned into 8 equally sized buckets. Before a position is queried for NN evaluation, the 50 move rule ply is checked. If the bucket containing the position already has nodes, the eval is copied from the one with the most visits.
-The speedup can be anywhere from 5% to 50% depending on how transposition-heavy the position is. The gain was measured at 20 elo on STC.
+The speedup can be anywhere from 5% to 50% depending on how transposition-heavy the position is. The gain was measured at 20 elo on STC. The nodes per second statistic is now calculated by the number of true nodes (called LowNode in the code) rather than edges (technically playouts, called Node in the code) so the reported value may be lower than on previous dag versions.
+
+This feature is disabled by default but can be enabled by specifying `-m` or `--move-rule-bucketing=true` in the config.
+
 
 ### CPUCT Utility Variance Scaling
 

--- a/build.cmd
+++ b/build.cmd
@@ -13,7 +13,7 @@ set EIGEN=false
 set TEST=false
 
 rem 2. Edit the paths for the build dependencies.
-set CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.0
+set CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.1
 set CUDNN_PATH=%CUDA_PATH%
 set OPENBLAS_PATH=C:\OpenBLAS
 set MKL_PATH=C:\Program Files (x86)\IntelSWTools\compilers_and_libraries\windows\mkl
@@ -63,7 +63,8 @@ meson build --backend %backend% --buildtype release -Ddx=%DX12% -Dcudnn=%CUDNN% 
 -Dmkl_include="%MKL_PATH%\include" -Dmkl_libdirs="%MKL_PATH%\lib\intel64" -Ddnnl_dir="%DNNL_PATH%" ^
 -Dopencl_libdirs="%OPENCL_LIB_PATH%" -Dopencl_include="%OPENCL_INCLUDE_PATH%" ^
 -Dopenblas_include="%OPENBLAS_PATH%\include" -Dopenblas_libdirs="%OPENBLAS_PATH%\lib" ^
--Ddefault_library=static
+-Ddefault_library=static -Donnx_libdir="C:\onnxruntime-win-x64-gpu-1.15.1\onnxruntime-win-x64-gpu-1.15.1\lib" ^
+-Donnx_include="C:\onnxruntime-win-x64-gpu-1.15.1\onnxruntime-win-x64-gpu-1.15.1\include" 
 
 if errorlevel 1 exit /b
 

--- a/meson.build
+++ b/meson.build
@@ -461,7 +461,7 @@ if get_option('build_backends')
     includes += include_directories('src/neural/cuda/')
 
     cuda_arguments = ['-c', '@INPUT@', '-o', '@OUTPUT@',
-                      '-I', meson.source_root() + '/subprojects/abseil-cpp-20211102.0',
+                      '-I', meson.source_root() + '/subprojects/abseil-cpp-20220623.0',
                       '-I', meson.current_source_dir() + '/src']
     if host_machine.system() == 'windows'
       if get_option('b_vscrt') == 'mt'

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -358,59 +358,62 @@ void Node::CancelScoreUpdate(uint32_t multivisit) {
 }
 
 void LowNode::FinalizeScoreUpdate(float v, float d, float m, float vs,
-                                  uint32_t multivisit) {
+                                  uint32_t multivisit, float multiweight) {
   assert(edges_);
   // Recompute Q.
-  wl_ += multivisit * (v - wl_) / (n_ + multivisit);
-  d_ += multivisit * (d - d_) / (n_ + multivisit);
-  m_ += multivisit * (m - m_) / (n_ + multivisit);
-  vs_ += multivisit * (vs - vs_) / (n_ + multivisit);
+  wl_ += multiweight * (v - wl_) / (weight_ + multiweight);
+  d_ += multiweight * (d - d_) / (weight_ + multiweight);
+  m_ += multiweight * (m - m_) / (weight_ + multiweight);
+  vs_ += multiweight * (vs - vs_) / (weight_ + multiweight);
 
   assert(WLDMInvariantsHold());
 
   // Increment N.
   n_ += multivisit;
+  weight_ += multiweight;
 }
 
 void LowNode::AdjustForTerminal(float v, float d, float m, float vs,
-                                uint32_t multivisit) {
+                                uint32_t multivisit, float multiweight) {
   assert(static_cast<uint32_t>(multivisit) <= n_);
 
   // Recompute Q.
-  wl_ += multivisit * v / n_;
-  d_ += multivisit * d / n_;
-  m_ += multivisit * m / n_;
-  vs_ += multivisit * vs / n_;
+  wl_ += multiweight * v / weight_;
+  d_ += multiweight * d / weight_;
+  m_ += multiweight * m / weight_;
+  vs_ += multiweight * vs / weight_;
 
   assert(WLDMInvariantsHold());
 }
 
 void Node::FinalizeScoreUpdate(float v, float d, float m, float vs,
-                               uint32_t multivisit) {
+                               uint32_t multivisit, float multiweight) {
   // Recompute Q.
-  wl_ += multivisit * (v - wl_) / (n_ + multivisit);
-  d_ += multivisit * (d - d_) / (n_ + multivisit);
-  m_ += multivisit * (m - m_) / (n_ + multivisit);
-  vs_ += multivisit * (vs - vs_) / (n_ + multivisit);
+  wl_ += multiweight * (v - wl_) / (weight_ + multiweight);
+  d_ += multiweight * (d - d_) / (weight_ + multiweight);
+  m_ += multiweight * (m - m_) / (weight_ + multiweight);
+  vs_ += multiweight * (vs - vs_) / (weight_ + multiweight);
 
   assert(WLDMInvariantsHold());
 
   // Increment N.
   n_ += multivisit;
+  weight_ += multiweight;
+
   // Decrement virtual loss.
   assert(GetNInFlight() >= (uint32_t)multivisit);
   n_in_flight_.fetch_sub(multivisit, std::memory_order_acq_rel);
 }
 
 void Node::AdjustForTerminal(float v, float d, float m, float vs,
-                             uint32_t multivisit) {
+                             uint32_t multivisit, float multiweight) {
   assert(static_cast<uint32_t>(multivisit) <= n_);
 
   // Recompute Q.
-  wl_ += multivisit * v / n_;
-  d_ += multivisit * d / n_;
-  m_ += multivisit * m / n_;
-  vs_ += multivisit * vs / n_;
+  wl_ += multiweight * v / weight_;
+  d_ += multiweight * d / weight_;
+  m_ += multiweight * m / weight_;
+  vs_ += multiweight * vs / weight_;
 
   assert(WLDMInvariantsHold());
 }

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -464,9 +464,9 @@ const OptionId SearchParams::kReportedNodesId{
     "What to report as nodes/nps count. Default is "
     "'nodes' for LowNodes. The other options are 'queries' for neural network"
       "queries and 'playouts' or 'legacy' for the old value."};
-const OptionId SearchParams::kUncertaintyWeightingMinimumId{
-    "uncertainty-weighting-minimum", "UncertaintyWeightingMinimum",
-		"Minimum number of visits for uncertainty weighting."};
+const OptionId SearchParams::kUncertaintyWeightingCapId{
+    "uncertainty-weighting-cap", "UncertaintyWeightingCap",
+		"Cap for node weight from uncertainty weighting."};
 const OptionId SearchParams::kUncertaintyWeightingAlphaId{
 		"uncertainty-weighting-alpha", "UncertaintyWeightingAlpha",
     "Alpha value for uncertainty weighting."};
@@ -580,10 +580,10 @@ void SearchParams::Populate(OptionsParser* options) {
   std::vector<std::string> reported_nodes = {"nodes", "queries", "playouts",
                                              "legacy"};
   options->Add<ChoiceOption>(kReportedNodesId, reported_nodes) = "nodes";
-  options->Add<FloatOption>(kUncertaintyWeightingMinimumId, 0.0f, 2.0f) =
-			0.5f;
+  options->Add<FloatOption>(kUncertaintyWeightingCapId, 0.0f, 2.0f) =
+			2.0f;
   options->Add<FloatOption>(kUncertaintyWeightingAlphaId, 0.0f, 100.0f) = 1.0f;
-  options->Add<FloatOption>(kUncertaintyWeightingBetaId, 0.0f, 100.0f) = 1.0f;
+  options->Add<FloatOption>(kUncertaintyWeightingBetaId, -10.0f, 0.0f) = -0.4f;
 
   options->HideOption(kNoiseEpsilonId);
   options->HideOption(kNoiseAlphaId);
@@ -703,7 +703,7 @@ SearchParams::SearchParams(const OptionsDict& options)
       kCpuctUtilityStdevPriorWeight(
           options.Get<float>(kCpuctUtilityStdevPriorWeightId)),
       kMoveRuleBucketing(options.Get<bool>(kMoveRuleBucketingId)),
-      kUncertaintyWeightingMinimum(options.Get<float>(kUncertaintyWeightingMinimumId)),
+      kUncertaintyWeightingCap(options.Get<float>(kUncertaintyWeightingCapId)),
       kUncertaintyWeightingAlpha(options.Get<float>(kUncertaintyWeightingAlphaId)),
       kUncertaintyWeightingBeta(options.Get<float>(kUncertaintyWeightingBetaId))
 

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -457,8 +457,13 @@ const OptionId SearchParams::kCpuctUtilityStdevPriorWeightId{
     "cpuct-utility-stdev-prior-weight", "CpuctUtilityStdevPriorWeight",
     "How much to weigh the prior value in the calculation of stdev."};
 const OptionId SearchParams::kMoveRuleBucketingId{
-		"move-rule-bucketing", "MoveRuleBucketing",
-    "Whether to use move rule bucketing.", 'm'};
+    "move-rule-bucketing", "MoveRuleBucketing",
+    "Whether to use move rule bucketing."};
+const OptionId SearchParams::kReportedNodesId{
+    "reported-nodes", "ReportedNodes",
+    "What to report as nodes/nps count. Default is "
+    "'nodes' for LowNodes. The other options are 'queries' for neural network"
+    "queries and 'playouts' or 'legacy' for the old value."};
 
 void SearchParams::Populate(OptionsParser* options) {
   // Here the uci optimized defaults" are set.
@@ -560,7 +565,10 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<FloatOption>(kCpuctUtilityStdevScaleId, 0.0f, 1.0f) = 0.0f;
   options->Add<FloatOption>(kCpuctUtilityStdevPriorWeightId, 0.0f, 10000.0f) =
       10.0f;
-  options->Add<BoolOption>(kMoveRuleBucketingId) = false;
+  options->Add<BoolOption>(kMoveRuleBucketingId) = true;
+  std::vector<std::string> reported_nodes = {"nodes", "queries", "playouts",
+                                             "legacy"};
+  options->Add<ChoiceOption>(kReportedNodesId, reported_nodes) = "nodes";
 
   options->HideOption(kNoiseEpsilonId);
   options->HideOption(kNoiseAlphaId);
@@ -679,8 +687,9 @@ SearchParams::SearchParams(const OptionsDict& options)
       kCpuctUtilityStdevScale(options.Get<float>(kCpuctUtilityStdevScaleId)),
       kCpuctUtilityStdevPriorWeight(
           options.Get<float>(kCpuctUtilityStdevPriorWeightId)),
-      kMoveRuleBucketing(
-        options.Get<bool>(kMoveRuleBucketingId)) {
+      kMoveRuleBucketing(options.Get<bool>(kMoveRuleBucketingId))
+
+{
   if (std::max(std::abs(kDrawScoreSidetomove), std::abs(kDrawScoreOpponent)) +
           std::max(std::abs(kDrawScoreWhite), std::abs(kDrawScoreBlack)) >
       1.0f) {

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -456,6 +456,9 @@ const OptionId SearchParams::kCpuctUtilityStdevScaleId{
 const OptionId SearchParams::kCpuctUtilityStdevPriorWeightId{
     "cpuct-utility-stdev-prior-weight", "CpuctUtilityStdevPriorWeight",
     "How much to weigh the prior value in the calculation of stdev."};
+const OptionId SearchParams::kMoveRuleBucketingId{
+		"move-rule-bucketing", "MoveRuleBucketing",
+    "Whether to use move rule bucketing.", 'm'};
 
 void SearchParams::Populate(OptionsParser* options) {
   // Here the uci optimized defaults" are set.
@@ -557,6 +560,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<FloatOption>(kCpuctUtilityStdevScaleId, 0.0f, 1.0f) = 0.0f;
   options->Add<FloatOption>(kCpuctUtilityStdevPriorWeightId, 0.0f, 10000.0f) =
       10.0f;
+  options->Add<BoolOption>(kMoveRuleBucketingId) = false;
 
   options->HideOption(kNoiseEpsilonId);
   options->HideOption(kNoiseAlphaId);
@@ -674,7 +678,9 @@ SearchParams::SearchParams(const OptionsDict& options)
       kCpuctUtilityStdevPrior(options.Get<float>(kCpuctUtilityStdevPriorId)),
       kCpuctUtilityStdevScale(options.Get<float>(kCpuctUtilityStdevScaleId)),
       kCpuctUtilityStdevPriorWeight(
-          options.Get<float>(kCpuctUtilityStdevPriorWeightId)) {
+          options.Get<float>(kCpuctUtilityStdevPriorWeightId)),
+      kMoveRuleBucketing(
+        options.Get<bool>(kMoveRuleBucketingId)) {
   if (std::max(std::abs(kDrawScoreSidetomove), std::abs(kDrawScoreOpponent)) +
           std::max(std::abs(kDrawScoreWhite), std::abs(kDrawScoreBlack)) >
       1.0f) {

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -463,7 +463,18 @@ const OptionId SearchParams::kReportedNodesId{
     "reported-nodes", "ReportedNodes",
     "What to report as nodes/nps count. Default is "
     "'nodes' for LowNodes. The other options are 'queries' for neural network"
-    "queries and 'playouts' or 'legacy' for the old value."};
+      "queries and 'playouts' or 'legacy' for the old value."};
+const OptionId SearchParams::kUncertaintyWeightingMinimumId{
+    "uncertainty-weighting-minimum", "UncertaintyWeightingMinimum",
+		"Minimum number of visits for uncertainty weighting."};
+const OptionId SearchParams::kUncertaintyWeightingAlphaId{
+		"uncertainty-weighting-alpha", "UncertaintyWeightingAlpha",
+    "Alpha value for uncertainty weighting."};
+const OptionId SearchParams::kUncertaintyWeightingBetaId{
+"uncertainty-weighting-beta", "UncertaintyWeightingBeta",
+		"Beta value for uncertainty weighting."};
+
+
 
 void SearchParams::Populate(OptionsParser* options) {
   // Here the uci optimized defaults" are set.
@@ -569,6 +580,10 @@ void SearchParams::Populate(OptionsParser* options) {
   std::vector<std::string> reported_nodes = {"nodes", "queries", "playouts",
                                              "legacy"};
   options->Add<ChoiceOption>(kReportedNodesId, reported_nodes) = "nodes";
+  options->Add<FloatOption>(kUncertaintyWeightingMinimumId, 0.0f, 2.0f) =
+			0.5f;
+  options->Add<FloatOption>(kUncertaintyWeightingAlphaId, 0.0f, 100.0f) = 1.0f;
+  options->Add<FloatOption>(kUncertaintyWeightingBetaId, 0.0f, 100.0f) = 1.0f;
 
   options->HideOption(kNoiseEpsilonId);
   options->HideOption(kNoiseAlphaId);
@@ -687,7 +702,10 @@ SearchParams::SearchParams(const OptionsDict& options)
       kCpuctUtilityStdevScale(options.Get<float>(kCpuctUtilityStdevScaleId)),
       kCpuctUtilityStdevPriorWeight(
           options.Get<float>(kCpuctUtilityStdevPriorWeightId)),
-      kMoveRuleBucketing(options.Get<bool>(kMoveRuleBucketingId))
+      kMoveRuleBucketing(options.Get<bool>(kMoveRuleBucketingId)),
+      kUncertaintyWeightingMinimum(options.Get<float>(kUncertaintyWeightingMinimumId)),
+      kUncertaintyWeightingAlpha(options.Get<float>(kUncertaintyWeightingAlphaId)),
+      kUncertaintyWeightingBeta(options.Get<float>(kUncertaintyWeightingBetaId))
 
 {
   if (std::max(std::abs(kDrawScoreSidetomove), std::abs(kDrawScoreOpponent)) +

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -158,6 +158,9 @@ class SearchParams {
     return kCpuctUtilityStdevPriorWeight;
   }
   bool GetMoveRuleBucketing() const { return kMoveRuleBucketing; }
+  std::string GetReportedNodes() const {
+    return options_.Get<std::string>(kReportedNodesId);
+  }
 
   // Search parameter IDs.
   static const OptionId kMiniBatchSizeId;
@@ -234,6 +237,7 @@ class SearchParams {
   static const OptionId kCpuctUtilityStdevScaleId;
   static const OptionId kCpuctUtilityStdevPriorWeightId;
   static const OptionId kMoveRuleBucketingId;
+  static const OptionId kReportedNodesId;
 
  private:
   const OptionsDict& options_;

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -157,6 +157,7 @@ class SearchParams {
   float GetCpuctUtilityStdevPriorWeight() const {
     return kCpuctUtilityStdevPriorWeight;
   }
+  bool GetMoveRuleBucketing() const { return kMoveRuleBucketing; }
 
   // Search parameter IDs.
   static const OptionId kMiniBatchSizeId;
@@ -232,6 +233,7 @@ class SearchParams {
   static const OptionId kCpuctUtilityStdevPriorId;
   static const OptionId kCpuctUtilityStdevScaleId;
   static const OptionId kCpuctUtilityStdevPriorWeightId;
+  static const OptionId kMoveRuleBucketingId;
 
  private:
   const OptionsDict& options_;
@@ -294,6 +296,7 @@ class SearchParams {
   const float kCpuctUtilityStdevPrior;
   const float kCpuctUtilityStdevScale;
   const float kCpuctUtilityStdevPriorWeight;
+  const bool kMoveRuleBucketing;
 };
 
 }  // namespace lczero

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -161,6 +161,16 @@ class SearchParams {
   std::string GetReportedNodes() const {
     return options_.Get<std::string>(kReportedNodesId);
   }
+  float GetUncertaintyWeightingMinimum() const {
+		return kUncertaintyWeightingMinimum;
+	}
+  float GetUncertaintyWeightingAlpha() const {
+    return kUncertaintyWeightingAlpha;
+  }
+  float GetUncertaintyWeightingBeta() const {
+    return kUncertaintyWeightingBeta;
+  }
+
 
   // Search parameter IDs.
   static const OptionId kMiniBatchSizeId;
@@ -238,6 +248,9 @@ class SearchParams {
   static const OptionId kCpuctUtilityStdevPriorWeightId;
   static const OptionId kMoveRuleBucketingId;
   static const OptionId kReportedNodesId;
+  static const OptionId kUncertaintyWeightingMinimumId;
+  static const OptionId kUncertaintyWeightingAlphaId;
+  static const OptionId kUncertaintyWeightingBetaId;
 
  private:
   const OptionsDict& options_;
@@ -301,6 +314,10 @@ class SearchParams {
   const float kCpuctUtilityStdevScale;
   const float kCpuctUtilityStdevPriorWeight;
   const bool kMoveRuleBucketing;
+  const float kUncertaintyWeightingMinimum;
+  const float kUncertaintyWeightingAlpha;
+  const float kUncertaintyWeightingBeta;
+
 };
 
 }  // namespace lczero

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -161,8 +161,8 @@ class SearchParams {
   std::string GetReportedNodes() const {
     return options_.Get<std::string>(kReportedNodesId);
   }
-  float GetUncertaintyWeightingMinimum() const {
-		return kUncertaintyWeightingMinimum;
+  float GetUncertaintyWeightingCap() const {
+		return kUncertaintyWeightingCap;
 	}
   float GetUncertaintyWeightingAlpha() const {
     return kUncertaintyWeightingAlpha;
@@ -248,7 +248,7 @@ class SearchParams {
   static const OptionId kCpuctUtilityStdevPriorWeightId;
   static const OptionId kMoveRuleBucketingId;
   static const OptionId kReportedNodesId;
-  static const OptionId kUncertaintyWeightingMinimumId;
+  static const OptionId kUncertaintyWeightingCapId;
   static const OptionId kUncertaintyWeightingAlphaId;
   static const OptionId kUncertaintyWeightingBetaId;
 
@@ -314,7 +314,7 @@ class SearchParams {
   const float kCpuctUtilityStdevScale;
   const float kCpuctUtilityStdevPriorWeight;
   const bool kMoveRuleBucketing;
-  const float kUncertaintyWeightingMinimum;
+  const float kUncertaintyWeightingCap;
   const float kUncertaintyWeightingAlpha;
   const float kUncertaintyWeightingBeta;
 

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -593,6 +593,7 @@ std::vector<std::string> Search::GetVerboseStats(Node* node) const {
     }
   };
 
+
   std::vector<std::string> infos;
   const auto m_evaluator = network_->GetCapabilities().has_mlh()
                                ? MEvaluator(params_, node)
@@ -619,6 +620,12 @@ std::vector<std::string> Search::GetVerboseStats(Node* node) const {
              node->GetNInFlight(), node->GetVisitedPolicy());
   print_stats(&oss, node);
   print_tail(&oss, node);
+
+  oss << std::endl << "Low nodes: " << total_low_nodes_
+       << " NN queries: " << total_nn_queries_
+       << " Playouts: " << total_playouts_ + initial_visits_;
+
+
   infos.emplace_back(oss.str());
   return infos;
 }

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -499,10 +499,10 @@ inline float ComputeCpuct(const SearchParams& params, float weight, float q,
 }
 
 inline float ComputeWeight(const SearchParams& params, float uncertainty) {
-  const float minimum = params.GetUncertaintyWeightingMinimum();
+  const float cap = params.GetUncertaintyWeightingCap();
   const float alpha = params.GetUncertaintyWeightingAlpha();
   const float beta = params.GetUncertaintyWeightingBeta();
-  return fmin(minimum, alpha * pow(uncertainty, beta));
+  return fmin(cap, alpha * pow(uncertainty, beta));
 }
 
 }  // namespace

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -498,6 +498,13 @@ inline float ComputeCpuct(const SearchParams& params, float weight, float q,
          (init + (k ? k * FastLog((weight + base) / base) : 0.0f));
 }
 
+inline float ComputeWeight(const SearchParams& params, float uncertainty) {
+  const float minimum = params.GetUncertaintyWeightingMinimum();
+  const float alpha = params.GetUncertaintyWeightingAlpha();
+  const float beta = params.GetUncertaintyWeightingBeta();
+  return fmin(minimum, alpha * pow(uncertainty, beta));
+}
+
 }  // namespace
 
 std::vector<std::string> Search::GetVerboseStats(Node* node) const {

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -310,6 +310,7 @@ class SearchWorker {
     // limit, multivist could be increased to this value without additional
     // change in outcome of next selection.
     uint32_t maxvisit = 0;
+    float avg_weight = 1.0f;
     bool nn_queried = false;
     bool is_tt_hit = false;
     bool is_comrade_hit = false;
@@ -443,13 +444,14 @@ class SearchWorker {
   // Return true if adjustment happened.
   bool MaybeAdjustForTerminalOrTransposition(Node* n, const LowNode* nl,
                                              float& v, float& d, float& m,
-                                             float& vs, uint32_t& n_to_fix,
+                                             float& vs, uint32_t& n_to_fix, float& weight_to_fix,
                                              float& v_delta, float& d_delta,
                                              float& m_delta, float& vs_delta,
                                              bool& update_parent_bounds) const;
   void DoBackupUpdateSingleNode(const NodeToProcess& node_to_process);
   // Returns whether a node's bounds were set based on its children.
-  bool MaybeSetBounds(Node* p, float m, uint32_t* n_to_fix, float* v_delta,
+  bool MaybeSetBounds(Node* p, float m, uint32_t* n_to_fix,
+                      float* weight_to_fix, float* v_delta,
                       float* d_delta, float* m_delta, float* vs_delta) const;
   void PickNodesToExtend(int collision_limit);
   void PickNodesToExtendTask(const BackupPath& path, int collision_limit,

--- a/src/utils/filesystem.h
+++ b/src/utils/filesystem.h
@@ -27,6 +27,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <time.h>
 #include <string>
 #include <vector>

--- a/src/version.h
+++ b/src/version.h
@@ -29,6 +29,7 @@
 // Versioning is performed according to the standard at <https://semver.org/>
 // Creating a new version should be performed using scripts/bumpversion.py.
 
+#include <cstdint>
 #include <string>
 #include "version.inc"
 #include "build_id.h"

--- a/subprojects/abseil-cpp.wrap
+++ b/subprojects/abseil-cpp.wrap
@@ -1,11 +1,12 @@
 [wrap-file]
-directory = abseil-cpp-20211102.0
-source_url = https://github.com/abseil/abseil-cpp/archive/20211102.0.tar.gz
-source_filename = abseil-cpp-20211102.0.tar.gz
-source_hash = dcf71b9cba8dc0ca9940c4b316a0c796be8fab42b070bb6b7cab62b48f0e66c4
-patch_filename = abseil-cpp_20211102.0-3_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/abseil-cpp_20211102.0-3/get_patch
-patch_hash = 3b49ff46df64414bac034b58bf36a07457375b6f8d8b5158e341157c6f9efad2
+directory = abseil-cpp-20220623.0
+source_url = https://github.com/abseil/abseil-cpp/archive/20220623.0.tar.gz
+source_filename = abseil-cpp-20220623.0.tar.gz
+source_hash = 4208129b49006089ba1d6710845a45e31c59b0ab6bff9e5788a87f55c5abd602
+patch_filename = abseil-cpp_20220623.0-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/abseil-cpp_20220623.0-2/get_patch
+patch_hash = d19cb16610d9310658a815ebcd87a9e2966aafbd57964341c0d1a3a3778c03b6
+wrapdb_version = 20220623.0-2
 
 [provide]
 absl_base = absl_base_dep
@@ -20,4 +21,3 @@ absl_strings = absl_strings_dep
 absl_synchronization = absl_synchronization_dep
 absl_time = absl_time_dep
 absl_types = absl_types_dep
-


### PR DESCRIPTION
Changes so can be compiled on up to date Arch-based linux system.  Without these changes, I could not compile the uncertainty-weighting branch (or any branch). I would receive many type errors associated with the missing '#include <cstdint>' statements and many GUARDED_BY(mutex) errors I believe associated with the older version of abseil.  My system uses gcc 13.2.1, clang 16.0.6, and cuda 12.2.0.  With these changes I could compile using either gcc or clang. This is my first time submitting a pull request, so I apologize if I've done it incorrectly.