### PR TITLE
Update for Linux compile

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -461,7 +461,7 @@ if get_option('build_backends')
     includes += include_directories('src/neural/cuda/')
 
     cuda_arguments = ['-c', '@INPUT@', '-o', '@OUTPUT@',
-                      '-I', meson.source_root() + '/subprojects/abseil-cpp-20211102.0',
+                      '-I', meson.source_root() + '/subprojects/abseil-cpp-20220623.0',
                       '-I', meson.current_source_dir() + '/src']
     if host_machine.system() == 'windows'
       if get_option('b_vscrt') == 'mt'

--- a/src/utils/filesystem.h
+++ b/src/utils/filesystem.h
@@ -27,6 +27,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <time.h>
 #include <string>
 #include <vector>

--- a/src/version.h
+++ b/src/version.h
@@ -29,6 +29,7 @@
 // Versioning is performed according to the standard at <https://semver.org/>
 // Creating a new version should be performed using scripts/bumpversion.py.
 
+#include <cstdint>
 #include <string>
 #include "version.inc"
 #include "build_id.h"

--- a/subprojects/abseil-cpp.wrap
+++ b/subprojects/abseil-cpp.wrap
@@ -1,11 +1,12 @@
 [wrap-file]
-directory = abseil-cpp-20211102.0
-source_url = https://github.com/abseil/abseil-cpp/archive/20211102.0.tar.gz
-source_filename = abseil-cpp-20211102.0.tar.gz
-source_hash = dcf71b9cba8dc0ca9940c4b316a0c796be8fab42b070bb6b7cab62b48f0e66c4
-patch_filename = abseil-cpp_20211102.0-3_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/abseil-cpp_20211102.0-3/get_patch
-patch_hash = 3b49ff46df64414bac034b58bf36a07457375b6f8d8b5158e341157c6f9efad2
+directory = abseil-cpp-20220623.0
+source_url = https://github.com/abseil/abseil-cpp/archive/20220623.0.tar.gz
+source_filename = abseil-cpp-20220623.0.tar.gz
+source_hash = 4208129b49006089ba1d6710845a45e31c59b0ab6bff9e5788a87f55c5abd602
+patch_filename = abseil-cpp_20220623.0-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/abseil-cpp_20220623.0-2/get_patch
+patch_hash = d19cb16610d9310658a815ebcd87a9e2966aafbd57964341c0d1a3a3778c03b6
+wrapdb_version = 20220623.0-2
 
 [provide]
 absl_base = absl_base_dep
@@ -20,4 +21,3 @@ absl_strings = absl_strings_dep
 absl_synchronization = absl_synchronization_dep
 absl_time = absl_time_dep
 absl_types = absl_types_dep
-


### PR DESCRIPTION
Changes so can be compiled on up to date Arch-based linux system. Without these changes, I could not compile the uncertainty-weighting branch (or any branch). I would receive many type errors associated with the missing '#include ' statements and many GUARDED_BY(mutex) errors I believe associated with the older version of abseil. My system uses gcc 13.2.1, clang 16.0.6, and cuda 12.2.0. With these changes I could compile using either gcc or clang. This is my first time submitting a pull request, so I apologize if I've done it incorrectly.