### PR TITLE
Support the ONNX conversion of ACTIVATION_NONE

### DIFF
--- a/src/neural/onnx/converter.cc
+++ b/src/neural/onnx/converter.cc
@@ -221,8 +221,10 @@ std::string Converter::MakeActivation(OnnxBuilder* builder,
       auto flow = builder->Relu(name + "/sqrrelu/relu", input);
       return builder->Mul(name + "/sqrrelu/sqr", flow, flow);
     }
+    case ACTIVATION_NONE:
+      return input;
     default:
-      throw Exception("Unsupposrted activation in " + name);
+      throw Exception("Unsupported activation in " + name);
   }
 }
 


### PR DESCRIPTION
Allows BT3 nets to be exported from Leela to ONNX. (`ACTIVATION_NONE` is used in BT3's smolgen)