### PR TITLE
Redirect networks with multiheaded attention from cuDNN to CUDA.

### DIFF
--- a/src/neural/cuda/network_cudnn.cc
+++ b/src/neural/cuda/network_cudnn.cc
@@ -1084,6 +1084,7 @@ std::unique_ptr<Network> MakeCudnnNetwork(const std::optional<WeightsFile>& w,
     case pblczero::NetworkFormat::NETWORK_SE_WITH_HEADFORMAT:
       break;
     case pblczero::NetworkFormat::NETWORK_ATTENTIONBODY_WITH_HEADFORMAT:
+    case pblczero::NetworkFormat::NETWORK_ATTENTIONBODY_WITH_MULTIHEADFORMAT:
       CERR << "Network format not supported by CuDNN backend, switching to "
               "CUDA.";
       return NetworkFactory::Get()->Create(


### PR DESCRIPTION
- The code currently only redirects networks with single-headed attention from cuDNN to CUDA. The patch allows multiheaded networks to be redirected as well.